### PR TITLE
Mark required columns in product import example CSV

### DIFF
--- a/.github/workflows/product-import-template-check.yml
+++ b/.github/workflows/product-import-template-check.yml
@@ -1,0 +1,18 @@
+name: Product Import Template Check
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - task-76
+
+jobs:
+  verify-template-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify product import template contract
+        run: node tools/verify-product-import-template.cjs

--- a/src/Service/Imports/ProductImportService.php
+++ b/src/Service/Imports/ProductImportService.php
@@ -35,6 +35,11 @@ class ProductImportService extends ImportCommon
         'item_active',
     ];
 
+    private const REQUIRED_CSV_HEADERS = [
+        'category_name',
+        'product_name',
+    ];
+
     public function __construct(
         private ProductService $productService
     ) {}
@@ -53,7 +58,12 @@ class ProductImportService extends ImportCommon
     {
         return [
             [
-                ...self::CSV_HEADERS,
+                ...array_map(
+                    fn(string $header): string => in_array($header, self::REQUIRED_CSV_HEADERS, true)
+                        ? $header . '*'
+                        : $header,
+                    self::CSV_HEADERS
+                ),
             ],
             [
                 'Lanches',

--- a/tools/verify-product-import-template.cjs
+++ b/tools/verify-product-import-template.cjs
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const productServicePath = path.join(root, 'src/Service/ProductService.php');
+const importServicePath = path.join(root, 'src/Service/Imports/ProductImportService.php');
+
+const productServiceSource = fs.readFileSync(productServicePath, 'utf8');
+const importServiceSource = fs.readFileSync(importServicePath, 'utf8');
+
+const requiredFieldMatches = [
+  ...productServiceSource.matchAll(
+    /\$this->hasValue\(\$data\['([^']+)'\] \?\? null\)\) {\s*throw new \\InvalidArgumentException\('([^']+)'\);/g,
+  ),
+];
+const requiredFieldsFromValidation = [
+  ...new Set(
+    requiredFieldMatches
+      .filter((match) => /obrigatorio\.$/.test(match[2]))
+      .map((match) => match[1]),
+  ),
+].sort();
+
+const requiredHeadersBlockMatch = importServiceSource.match(
+  /private const REQUIRED_CSV_HEADERS = \[(.*?)\];/s,
+);
+
+if (!requiredHeadersBlockMatch) {
+  throw new Error('Constante REQUIRED_CSV_HEADERS nao encontrada.');
+}
+
+const requiredHeaders = [
+  ...requiredHeadersBlockMatch[1].matchAll(/'([^']+)'/g),
+].map((match) => match[1]).sort();
+
+if (
+  requiredFieldsFromValidation.length !== requiredHeaders.length ||
+  requiredFieldsFromValidation.some((field, index) => field !== requiredHeaders[index])
+) {
+  throw new Error(
+    `Cabecalhos obrigatorios divergentes. validateImportRow=${JSON.stringify(requiredFieldsFromValidation)} REQUIRED_CSV_HEADERS=${JSON.stringify(requiredHeaders)}`,
+  );
+}
+
+if (!/\? \$header \. '\*'/.test(importServiceSource)) {
+  throw new Error('A marcacao de obrigatoriedade com * nao foi encontrada em getExampleCsv.');
+}
+
+console.log(
+  `Contrato de importacao verificado com sucesso: ${requiredHeaders.join(', ')}`,
+);


### PR DESCRIPTION
Atende a issue `ControleOnline/app-community#76`.

## O que mudou
- marca com `*` as colunas realmente obrigatórias no cabeçalho do CSV de exemplo da importação de produtos
- mantém o restante do modelo e do contrato de importação sem mudanças
- adiciona um check automatizado leve para garantir que os cabeçalhos obrigatórios do exemplo permaneçam alinhados ao contrato validado em `ProductService`

## Impacto entre projetos
- `app-community`: fluxo agregador do manager para importação de produtos
- `api-community`: entrega o ajuste via módulo `api-platform-products`, que passa a ser a fonte canônica dos `*` no CSV
- `api-whatsapp`: sem impacto identificado

## Validação
- `node tools/verify-product-import-template.cjs`
- workflow `Product Import Template Check` concluído com sucesso no commit `1ecd687`

## Observação
- o `ui-common` deixou de decorar cabeçalhos localmente e voltou a apenas baixar o CSV exatamente como a API entrega, eliminando a divergência apontada em QA
- o status `Scrutinizer` deste commit caiu como falha por inspeção cancelada sem tarefas executadas, então a evidência técnica desta entrega ficou ancorada no novo check do repositório
- este repositório não expõe branch `dev`, então a revisão segue para `master` para manter o diff isolado e revisável.