### PR TITLE
Validate service billing units for issue #100

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,28 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-100
+
+jobs:
+  products-module:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Validate composer files
+        run: composer validate --no-check-publish
+
+      - name: Install test dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,29 @@
+checks:
+  php: true
+
+build:
+  nodes:
+    analysis:
+      environment:
+        php:
+          version: "8.3.0"
+      dependencies:
+        override:
+          - composer self-update --2
+          - composer install --no-interaction --no-progress --prefer-dist --no-scripts --no-security-blocking
+          - composer require --dev --no-interaction --no-progress --no-scripts squizlabs/php_codesniffer:^3.11
+      tests:
+        override:
+          - command: phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml
+            coverage:
+              file: coverage.xml
+              format: php-clover
+          - command: phpcs-run
+            use_website_config: true
+
+filter:
+  excluded_paths:
+    - "tests/*"
+    - "var/*"
+    - "vendor/*"
+    - "public/vendor/*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,7 @@
 - Regras de venda e pedido pertencem a `orders`.
 - Regras de fila operacional de preparo pertencem a `queue`.
 - Os metadados de grupo de produto (`priceCalculation`, `required`, `minimum`, `maximum`) e a quantidade/preco padrao de `product_group_product` formam o contrato de catalogo consumido pela tela de customizacao no frontend. Mudancas nesses campos precisam manter a leitura previsivel para `CustomizeScreen`.
+- `ProductService` e o dono da fronteira de autorizacao do catalogo. `securityFilter()` deve limitar leitura de `Product` as empresas realmente acessiveis ao ator autenticado, incluindo a propria empresa quando o usuario opera o catalogo da pessoa dona.
+- Criacao, edicao, exclusao e importacao CSV de `Product` exigem acesso administrativo de catalogo para a empresa alvo. `ROLE_HUMAN` isolado nao basta para gravar no catalogo.
+- Endpoints derivados de leitura, como inventario, sugestao de compra e busca por SKU, devem reutilizar a mesma regra de visibilidade por empresa e falhar fechado quando a empresa solicitada nao estiver no escopo acessivel.
+- Quando `Product.type = service`, a persistencia deve aceitar apenas unidades de cobranca compativeis com execucao unica ou recorrencia. Medidas fisicas como litro, grama e fracao nao podem ser salvas para servicos mesmo se o payload contornar o frontend.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,49 @@
 
 # products
 
-
 `composer require controleonline/products:dev-master`
 
+## Service import
 
-Add Service import:
-config\services.yaml
+Add the module service import in `config/services.yaml`:
 
 ```yaml
 imports:
-    - { resource: "../modules/controleonline/orders/products/services/products.yaml" }    
+    - { resource: "../modules/controleonline/orders/products/services/products.yaml" }
 ```
+
+## Product access rules
+
+This module now enforces the product catalog access rules in the backend.
+
+- product reads are limited to companies the authenticated actor can actually access
+- create, update, delete and CSV import require catalog-management access for the target company
+- inventory, SKU lookup and purchase-suggestion endpoints reuse the same company visibility rule
+
+## Service billing units
+
+For products with `type=service`, the backend only accepts billing units compatible with one-time or recurring service charging.
+
+Examples of compatible units:
+
+- `unitario`
+- `hora`
+- `diaria`
+- `semanal`
+- `mensal`
+
+Examples of incompatible physical units:
+
+- `litro`
+- `grama`
+- `fracao`
+
+The entity validation rejects incompatible units during persist and update, even if a request bypasses the frontend form restrictions.
+
+## Validation
+
+The pull request checks for this module currently cover:
+
+- `composer validate --no-check-publish`
+- `composer install --no-interaction --prefer-dist`
+- `vendor/bin/phpunit`

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   ],
   "require": {},
   "require-dev": {
+    "doctrine/collections": "^2.3",
     "phpunit/phpunit": "^12.1"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,19 @@
       "ControleOnline\\Controller\\": "src/Controller/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "ControleOnline\\Products\\Tests\\": "tests/"
+    }
+  },
   "authors": [
     {
       "name": "Controle Online",
       "email": "luiz.kim@controleonline.com"
     }
   ],
-  "require": {}
+  "require": {},
+  "require-dev": {
+    "phpunit/phpunit": "^12.1"
+  }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="Products Module Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -23,11 +23,11 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ApiResource(
     operations: [
-        new Get(security: 'is_granted(\'PUBLIC_ACCESS\')'),
+        new Get(security: 'is_granted(\'ROLE_HUMAN\')'),
         new Put(security: 'is_granted(\'ROLE_HUMAN\')', denormalizationContext: ['groups' => ['product:write']]),
         new Delete(security: 'is_granted(\'ROLE_HUMAN\')'),
-        new Post(securityPostDenormalize: 'is_granted(\'ROLE_HUMAN\')'),
-        new GetCollection(security: 'is_granted(\'PUBLIC_ACCESS\')'),
+        new Post(security: 'is_granted(\'ROLE_HUMAN\')', securityPostDenormalize: 'is_granted(\'ROLE_HUMAN\')'),
+        new GetCollection(security: 'is_granted(\'ROLE_HUMAN\')'),
     ],
     formats: ['jsonld', 'json', 'html', 'jsonhal', 'csv' => ['text/csv']],
     normalizationContext: ['groups' => ['product:read']],

--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -42,8 +42,24 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(name: 'default_in_inventory_id', columns: ['default_in_inventory_id'])]
 #[ORM\UniqueConstraint(name: 'company_id', columns: ['company_id', 'sku'])]
 #[ORM\Entity(repositoryClass: ProductRepository::class)]
+#[ORM\HasLifecycleCallbacks]
 class Product
 {
+    private const SERVICE_TYPE = 'service';
+    private const SERVICE_BILLING_PATTERNS = [
+        '/\bmes\b|mens|month/',
+        '/\bsem\b|seman|week/',
+        '/quinzen/',
+        '/bimens|bimes|bimestre/',
+        '/trimes|quarter/',
+        '/semes/',
+        '/anual|year/',
+        '/\bhr\b|hora|hour/',
+        '/\bdia\b|diar|day/',
+        '/unitar|execucao unica|execucao|avuls|\bun\b|\bund\b|unic[ao]?/',
+        '/atend|sess/',
+    ];
+
     #[ApiFilter(filterClass: SearchFilter::class, properties: ['id' => 'exact'])]
     #[ORM\Column(name: 'id', type: 'integer', nullable: false)]
     #[ORM\Id]
@@ -339,5 +355,59 @@ class Product
     public function getExtraData()
     {
         return $this->extraData;
+    }
+
+    #[ORM\PrePersist]
+    #[ORM\PreUpdate]
+    public function validateServiceUnitCompatibility(): void
+    {
+        if ($this->type !== self::SERVICE_TYPE || !$this->productUnit instanceof ProductUnity) {
+            return;
+        }
+
+        if ($this->isCompatibleServiceUnit($this->productUnit)) {
+            return;
+        }
+
+        $label = $this->productUnit->getDescription() ?: $this->productUnit->getProductUnit();
+
+        throw new \InvalidArgumentException(
+            sprintf(
+                'Produtos do tipo service aceitam apenas unidades de cobranca compativeis com execucao unica ou recorrencia. Unidade "%s" e invalida.',
+                $label
+            )
+        );
+    }
+
+    private function isCompatibleServiceUnit(ProductUnity $productUnit): bool
+    {
+        $normalized = $this->normalizeServiceUnitLabel(implode(' ', array_filter([
+            $productUnit->getProductUnit(),
+            $productUnit->getDescription(),
+        ])));
+
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach (self::SERVICE_BILLING_PATTERNS as $pattern) {
+            if (preg_match($pattern, $normalized) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function normalizeServiceUnitLabel(string $value): string
+    {
+        $asciiValue = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $value);
+        if ($asciiValue === false) {
+            $asciiValue = $value;
+        }
+
+        $normalized = strtolower(trim($asciiValue));
+
+        return preg_replace('/\s+/', ' ', $normalized) ?: '';
     }
 }

--- a/src/Security/ProductAccessPolicy.php
+++ b/src/Security/ProductAccessPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ControleOnline\Security;
+
+final class ProductAccessPolicy
+{
+    public function canReadCompany(int $companyId, ?int $currentPeopleId, array $accessibleCompanyIds): bool
+    {
+        if ($companyId <= 0) {
+            return false;
+        }
+
+        if ($currentPeopleId !== null && $currentPeopleId === $companyId) {
+            return true;
+        }
+
+        return in_array($companyId, $this->normalizeIds($accessibleCompanyIds), true);
+    }
+
+    public function canManageCompany(int $companyId, array $managedCompanyIds): bool
+    {
+        if ($companyId <= 0) {
+            return false;
+        }
+
+        return in_array($companyId, $this->normalizeIds($managedCompanyIds), true);
+    }
+
+    private function normalizeIds(array $ids): array
+    {
+        $normalized = [];
+
+        foreach ($ids as $id) {
+            $numericId = (int) $id;
+            if ($numericId > 0) {
+                $normalized[$numericId] = $numericId;
+            }
+        }
+
+        return array_values($normalized);
+    }
+}

--- a/src/Service/ProductService.php
+++ b/src/Service/ProductService.php
@@ -259,7 +259,7 @@ class ProductService
             throw new \InvalidArgumentException('Empresa da importacao nao informada.');
         }
 
-        $this->denyUnlessCanReadCompany($company);
+        $this->denyUnlessCanManageCompany($company);
 
         $data = $this->normalizeImportRow($row);
         $this->validateImportRow($data);
@@ -806,6 +806,11 @@ class ProductService
             throw new AccessDeniedHttpException('Product company is required.');
         }
 
+        $this->denyUnlessCanManageCompany($company);
+    }
+
+    private function denyUnlessCanManageCompany(People $company): void
+    {
         if ($this->canManageCompany($company)) {
             return;
         }

--- a/src/Service/ProductService.php
+++ b/src/Service/ProductService.php
@@ -5,18 +5,20 @@ namespace ControleOnline\Service;
 use ControleOnline\Entity\Category;
 use ControleOnline\Entity\Device;
 use ControleOnline\Entity\People;
+use ControleOnline\Entity\PeopleLink;
 use ControleOnline\Entity\Product;
 use ControleOnline\Entity\ProductCategory;
 use ControleOnline\Entity\ProductGroup;
 use ControleOnline\Entity\ProductGroupProduct;
 use ControleOnline\Entity\ProductUnity;
 use ControleOnline\Entity\Spool;
+use ControleOnline\Security\ProductAccessPolicy;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
-as Security;
 use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface as Security;
 
 class ProductService
 {
@@ -35,11 +37,38 @@ class ProductService
 
     public function securityFilter(QueryBuilder $queryBuilder, $resourceClass = null, $applyTo = null, $rootAlias = null): void
     {
-        // $this->PeopleService->checkCompany('company', $queryBuilder, $resourceClass, $applyTo, $rootAlias);
+        $myPeople = $this->PeopleService->getMyPeople();
+        $accessibleCompanyIds = $this->getAccessibleCompanyIds();
+
+        if (!$myPeople instanceof People && $accessibleCompanyIds === []) {
+            $queryBuilder->andWhere('1 = 0');
+            return;
+        }
+
+        $companyAlias = 'product_company';
+        if (!in_array($companyAlias, $queryBuilder->getAllAliases(), true)) {
+            $queryBuilder->innerJoin(sprintf('%s.company', $rootAlias), $companyAlias);
+        }
+
+        $visibilityConditions = [];
+
+        if ($myPeople instanceof People) {
+            $visibilityConditions[] = sprintf('%s.id = :myPeopleId', $companyAlias);
+            $queryBuilder->setParameter('myPeopleId', (int) $myPeople->getId());
+        }
+
+        if ($accessibleCompanyIds !== []) {
+            $visibilityConditions[] = sprintf('%s.id IN(:accessibleCompanyIds)', $companyAlias);
+            $queryBuilder->setParameter('accessibleCompanyIds', $accessibleCompanyIds);
+        }
+
+        $queryBuilder->andWhere($queryBuilder->expr()->orX(...$visibilityConditions));
     }
 
     public function getProductsInventory(People $company): array
     {
+        $this->denyUnlessCanReadCompany($company);
+
         return $this->manager->getRepository(Product::class)->getProductsInventory($company);
     }
 
@@ -72,6 +101,27 @@ class ProductService
         );
     }
 
+    public function prePersist(Product $product): Product
+    {
+        $this->denyUnlessCanManageCatalog($product);
+
+        return $product;
+    }
+
+    public function preUpdate(Product $product): Product
+    {
+        $this->denyUnlessCanManageCatalog($product);
+
+        return $product;
+    }
+
+    public function preRemove(Product $product): Product
+    {
+        $this->denyUnlessCanManageCatalog($product);
+
+        return $product;
+    }
+
     public function productsInventoryPrintData(People $provider, Device $device): Spool
     {
         $products = $this->getProductsInventory($provider);
@@ -87,30 +137,32 @@ class ProductService
 
         foreach ($groupedByInventory as $inventoryName => $items) {
             $companyName = $items[0]['company_name'];
-            $this->printService->addLine("", "", "-");
-            $this->printService->addLine($companyName, "", " ");
-            $this->printService->addLine("INVENTARIO: " . $inventoryName, "", " ");
-            $this->printService->addLine("", "", "-");
-            $this->printService->addLine("Produto", "Disponivel", " ");
-            $this->printService->addLine("", "", "-");
+            $this->printService->addLine('', '', '-');
+            $this->printService->addLine($companyName, '', ' ');
+            $this->printService->addLine('INVENTARIO: ' . $inventoryName, '', ' ');
+            $this->printService->addLine('', '', '-');
+            $this->printService->addLine('Produto', 'Disponivel', ' ');
+            $this->printService->addLine('', '', '-');
 
             foreach ($items as $item) {
                 $productName = substr($item['product_name'], 0, 20);
                 if (!empty($item['description'])) {
-                    $productName .= " " . substr($item['description'], 0, 10);
+                    $productName .= ' ' . substr($item['description'], 0, 10);
                 }
-                $productName .= " (" . $item['productUnit'] . ")";
-                $available = str_pad($item['available'], 4, " ", STR_PAD_LEFT);
-                $this->printService->addLine($productName, $available, " ");
+                $productName .= ' (' . $item['productUnit'] . ')';
+                $available = str_pad($item['available'], 4, ' ', STR_PAD_LEFT);
+                $this->printService->addLine($productName, $available, ' ');
             }
 
-            $this->printService->addLine("", "", "-");
+            $this->printService->addLine('', '', '-');
         }
         return $this->printService->generatePrintData($device, $provider);
     }
 
     public function getPurchasingSuggestion(People $company)
     {
+        $this->denyUnlessCanReadCompany($company);
+
         return $this->manager->getRepository(Product::class)->getPurchasingSuggestion($company);
     }
 
@@ -142,6 +194,8 @@ class ProductService
             throw new NotFoundHttpException('Empresa não encontrada');
         }
 
+        $this->denyUnlessCanReadCompany($company);
+
         $product = $this->manager
             ->getRepository(Product::class)
             ->findProductBySkuAsInteger($sku, $company);
@@ -171,29 +225,29 @@ class ProductService
             $groupedByCompany[$companyName][] = $product;
         }
 
-        $this->printService->addLine("", "", "-");
-        $this->printService->addLine("SUGESTAO DE COMPRA", "", " ");
-        $this->printService->addLine("", "", "-");
+        $this->printService->addLine('', '', '-');
+        $this->printService->addLine('SUGESTAO DE COMPRA', '', ' ');
+        $this->printService->addLine('', '', '-');
 
         foreach ($groupedByCompany as $companyName => $items) {
-            $this->printService->addLine($companyName, "", " ");
-            $this->printService->addLine("", "", "-");
-            $this->printService->addLine("Produto", "Necessario", " ");
-            $this->printService->addLine("", "", "-");
+            $this->printService->addLine($companyName, '', ' ');
+            $this->printService->addLine('', '', '-');
+            $this->printService->addLine('Produto', 'Necessario', ' ');
+            $this->printService->addLine('', '', '-');
 
             foreach ($items as $item) {
                 $productName = substr($item['product_name'], 0, 20);
                 if (!empty($item['description'])) {
-                    $productName .= " " . substr($item['description'], 0, 10);
+                    $productName .= ' ' . substr($item['description'], 0, 10);
                 }
                 if (!empty($item['unity'])) {
-                    $productName .= " (" . $item['unity'] . ")";
+                    $productName .= ' (' . $item['unity'] . ')';
                 }
-                $needed = str_pad($item['needed'], 4, " ", STR_PAD_LEFT);
-                $this->printService->addLine($productName, $needed, " ");
+                $needed = str_pad($item['needed'], 4, ' ', STR_PAD_LEFT);
+                $this->printService->addLine($productName, $needed, ' ');
             }
 
-            $this->printService->addLine("", "", "-");
+            $this->printService->addLine('', '', '-');
         }
 
         return $this->printService->generatePrintData($device, $provider);
@@ -204,6 +258,8 @@ class ProductService
         if (!$company instanceof People) {
             throw new \InvalidArgumentException('Empresa da importacao nao informada.');
         }
+
+        $this->denyUnlessCanReadCompany($company);
 
         $data = $this->normalizeImportRow($row);
         $this->validateImportRow($data);
@@ -728,5 +784,102 @@ class ProductService
         }
 
         return false;
+    }
+
+    private function denyUnlessCanReadCompany(People $company): void
+    {
+        if ($this->getAccessPolicy()->canReadCompany(
+            (int) $company->getId(),
+            $this->normalizePeopleId($this->PeopleService->getMyPeople()),
+            $this->getAccessibleCompanyIds()
+        )) {
+            return;
+        }
+
+        throw new AccessDeniedHttpException('Company access denied.');
+    }
+
+    private function denyUnlessCanManageCatalog(Product $product): void
+    {
+        $company = $product->getCompany();
+        if (!$company instanceof People) {
+            throw new AccessDeniedHttpException('Product company is required.');
+        }
+
+        if ($this->canManageCompany($company)) {
+            return;
+        }
+
+        throw new AccessDeniedHttpException('You are not allowed to manage this company catalog.');
+    }
+
+    private function canManageCompany(People $company): bool
+    {
+        if (method_exists($this->PeopleService, 'canAccessCompany')) {
+            return (bool) $this->PeopleService->canAccessCompany($company, null, PeopleLink::MANAGER_LINK);
+        }
+
+        return $this->getAccessPolicy()->canManageCompany(
+            (int) $company->getId(),
+            $this->getManagedCompanyIds()
+        );
+    }
+
+    private function getAccessibleCompanyIds(): array
+    {
+        if (!method_exists($this->PeopleService, 'getMyCompanies')) {
+            return [];
+        }
+
+        return $this->extractPeopleIds($this->PeopleService->getMyCompanies());
+    }
+
+    private function getManagedCompanyIds(): array
+    {
+        if (!method_exists($this->PeopleService, 'getMyCompanies')) {
+            return [];
+        }
+
+        try {
+            $companies = $this->PeopleService->getMyCompanies(PeopleLink::MANAGER_LINK);
+        } catch (\Throwable) {
+            $companies = [];
+        }
+
+        return $this->extractPeopleIds($companies);
+    }
+
+    private function extractPeopleIds(iterable $companies): array
+    {
+        $ids = [];
+
+        foreach ($companies as $company) {
+            if (!$company instanceof People) {
+                continue;
+            }
+
+            $companyId = (int) $company->getId();
+            if ($companyId > 0) {
+                $ids[$companyId] = $companyId;
+            }
+        }
+
+        return array_values($ids);
+    }
+
+    private function normalizePeopleId(mixed $people): ?int
+    {
+        if (!$people instanceof People) {
+            return null;
+        }
+
+        $peopleId = (int) $people->getId();
+
+        return $peopleId > 0 ? $peopleId : null;
+    }
+
+    private function getAccessPolicy(): ProductAccessPolicy
+    {
+        return new ProductAccessPolicy();
     }
 }

--- a/tests/Entity/ProductTest.php
+++ b/tests/Entity/ProductTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace ControleOnline\Products\Tests\Entity;
+
+use ControleOnline\Entity\Product;
+use ControleOnline\Entity\ProductUnity;
+use PHPUnit\Framework\TestCase;
+
+class ProductTest extends TestCase
+{
+    public function testServiceRejectsPhysicalMeasurementUnits(): void
+    {
+        $product = (new Product())
+            ->setType('service')
+            ->setProductUnit($this->createUnit('LT', 'Litro'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Produtos do tipo service aceitam apenas unidades de cobranca');
+
+        $product->validateServiceUnitCompatibility();
+    }
+
+    public function testServiceAllowsRecurringAndExecutionBillingUnits(): void
+    {
+        $allowedUnits = [
+            $this->createUnit('UN', 'Unitario'),
+            $this->createUnit('MES', 'Mensal'),
+            $this->createUnit('HR', 'Hora tecnica'),
+        ];
+
+        foreach ($allowedUnits as $unit) {
+            $product = (new Product())
+                ->setType('service')
+                ->setProductUnit($unit);
+
+            $product->validateServiceUnitCompatibility();
+            self::assertTrue(true);
+        }
+    }
+
+    public function testNonServiceKeepsPhysicalMeasurementUnits(): void
+    {
+        $product = (new Product())
+            ->setType('product')
+            ->setProductUnit($this->createUnit('LT', 'Litro'));
+
+        $product->validateServiceUnitCompatibility();
+
+        self::assertTrue(true);
+    }
+
+    private function createUnit(string $code, string $description): ProductUnity
+    {
+        return (new ProductUnity())
+            ->setProductUnit($code)
+            ->setDescription($description);
+    }
+}

--- a/tests/Security/ProductAccessPolicyTest.php
+++ b/tests/Security/ProductAccessPolicyTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ControleOnline\Products\Tests\Security;
+
+use ControleOnline\Security\ProductAccessPolicy;
+use PHPUnit\Framework\TestCase;
+
+class ProductAccessPolicyTest extends TestCase
+{
+    public function testCompanyOwnerCanReadOwnCatalog(): void
+    {
+        $policy = new ProductAccessPolicy();
+
+        self::assertTrue($policy->canReadCompany(12, 12, []));
+    }
+
+    public function testEmployeeCanReadAccessibleCompanyCatalog(): void
+    {
+        $policy = new ProductAccessPolicy();
+
+        self::assertTrue($policy->canReadCompany(18, 7, [18, 22, 18]));
+    }
+
+    public function testUnauthorizedPeopleCannotReadForeignCatalog(): void
+    {
+        $policy = new ProductAccessPolicy();
+
+        self::assertFalse($policy->canReadCompany(18, 7, [22]));
+    }
+
+    public function testOnlyManagedCompaniesCanBeChanged(): void
+    {
+        $policy = new ProductAccessPolicy();
+
+        self::assertTrue($policy->canManageCompany(44, [10, 44, 91]));
+        self::assertFalse($policy->canManageCompany(45, [10, 44, 91]));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+$autoloadPaths = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+];
+
+foreach ($autoloadPaths as $autoloadPath) {
+    if (is_file($autoloadPath)) {
+        require_once $autoloadPath;
+        return;
+    }
+}
+
+throw new RuntimeException('Composer autoload.php not found for products module tests.');


### PR DESCRIPTION
## Summary
- keep the existing service-unit validation for `type=service`
- restrict product reads to companies the authenticated actor can actually access
- require manager-level catalog access for create, update, delete and CSV import flows
- add focused PHPUnit coverage for the new catalog access policy helper

## Why
Security review on `ControleOnline/app-community#100` pointed out that backend validation had improved data integrity, but `Product` still exposed a broad read/write surface because the resource remained open to `PUBLIC_ACCESS` and `ProductService::securityFilter()` was effectively empty. This update closes that authorization gap in the products API itself.

## Validation
- existing `ProductTest` still covers compatible vs incompatible billing units for `service`
- new `ProductAccessPolicyTest` covers readable vs manageable company decisions
- GitHub Actions workflow `Pull Request Checks` is running on the current head `5de49fc23345eb97b61f004b3be1edebce37fb04`

## Issue
- relates to `ControleOnline/app-community#100`

## Note
- this repository does not expose a `dev` branch, so the review targets `master` to keep the diff isolated
- `Scrutinizer` is still pending on the new head while this update is being published