### PR TITLE
Protect product supplier links for issue #98

### DIFF
--- a/src/Service/ProductPeopleService.php
+++ b/src/Service/ProductPeopleService.php
@@ -9,13 +9,11 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface as Security;
 
 class ProductPeopleService
 {
     public function __construct(
         private EntityManagerInterface $manager,
-        private Security $security,
         private PeopleService $peopleService,
         private ProductService $productService
     ) {}

--- a/src/Service/ProductPeopleService.php
+++ b/src/Service/ProductPeopleService.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace ControleOnline\Service;
+
+use ControleOnline\Entity\People;
+use ControleOnline\Entity\Product;
+use ControleOnline\Entity\ProductPeople;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface as Security;
+
+class ProductPeopleService
+{
+    public function __construct(
+        private EntityManagerInterface $manager,
+        private Security $security,
+        private PeopleService $peopleService,
+        private ProductService $productService
+    ) {}
+
+    public function securityFilter(QueryBuilder $queryBuilder, $resourceClass = null, $applyTo = null, $rootAlias = null): void
+    {
+        $aliases = $queryBuilder->getAllAliases();
+
+        if (!in_array('productPeopleProduct', $aliases, true)) {
+            $queryBuilder->innerJoin(sprintf('%s.product', $rootAlias), 'productPeopleProduct');
+        }
+
+        if (!in_array('productPeopleLinkedPeople', $aliases, true)) {
+            $queryBuilder->innerJoin(sprintf('%s.people', $rootAlias), 'productPeopleLinkedPeople');
+        }
+
+        $this->productService->securityFilter($queryBuilder, $resourceClass, $applyTo, 'productPeopleProduct');
+        $this->peopleService->checkLink($queryBuilder, $resourceClass, $applyTo, 'productPeopleLinkedPeople');
+        $queryBuilder->distinct();
+    }
+
+    public function prePersist(ProductPeople $productPeople): void
+    {
+        $this->assertMutationAllowed($productPeople);
+    }
+
+    public function preUpdate(ProductPeople $productPeople): void
+    {
+        $this->assertMutationAllowed($productPeople);
+    }
+
+    public function preRemove(ProductPeople $productPeople): void
+    {
+        $this->assertMutationAllowed($productPeople);
+    }
+
+    private function assertMutationAllowed(ProductPeople $productPeople): void
+    {
+        $product = $productPeople->getProduct();
+        $people = $productPeople->getPeople();
+
+        if (!$product instanceof Product) {
+            throw new BadRequestHttpException('Produto obrigatorio para o vinculo de fornecedor.');
+        }
+
+        if (!$people instanceof People) {
+            throw new BadRequestHttpException('Pessoa obrigatoria para o vinculo de fornecedor.');
+        }
+
+        $this->productService->assertCanManageProduct($product);
+
+        if (!$this->isPeopleVisible($people)) {
+            throw new AccessDeniedHttpException('Voce nao pode vincular esta pessoa ao produto informado.');
+        }
+    }
+
+    private function isPeopleVisible(People $people): bool
+    {
+        if ($people->getId() === null) {
+            return false;
+        }
+
+        $queryBuilder = $this->manager->getRepository(People::class)->createQueryBuilder('productPeopleVisiblePeople');
+        $queryBuilder->andWhere('productPeopleVisiblePeople.id = :productPeopleVisiblePeopleId');
+        $queryBuilder->setParameter('productPeopleVisiblePeopleId', (int) $people->getId());
+
+        $this->peopleService->checkLink($queryBuilder, People::class, null, 'productPeopleVisiblePeople');
+
+        return $queryBuilder
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult() instanceof People;
+    }
+}

--- a/src/Service/ProductService.php
+++ b/src/Service/ProductService.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
 as Security;
 use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -36,7 +37,35 @@ class ProductService
 
     public function securityFilter(QueryBuilder $queryBuilder, $resourceClass = null, $applyTo = null, $rootAlias = null): void
     {
-        // $this->PeopleService->checkCompany('company', $queryBuilder, $resourceClass, $applyTo, $rootAlias);
+        $this->PeopleService->checkCompany('company', $queryBuilder, $resourceClass, $applyTo, $rootAlias);
+    }
+
+    public function prePersist(Product $product): void
+    {
+        $this->assertCanManageProduct($product);
+    }
+
+    public function preUpdate(Product $product): void
+    {
+        $this->assertCanManageProduct($product);
+    }
+
+    public function preRemove(Product $product): void
+    {
+        $this->assertCanManageProduct($product);
+    }
+
+    public function assertCanManageProduct(Product $product): void
+    {
+        $company = $product->getCompany();
+
+        if (!$company instanceof People) {
+            throw new BadRequestHttpException('Empresa não encontrada para o produto informado.');
+        }
+
+        if (!$this->PeopleService->canAccessCompany($company)) {
+            throw new AccessDeniedHttpException('Você não pode gerir o catálogo desta empresa.');
+        }
     }
 
     public function getProductsInventory(People $company): array


### PR DESCRIPTION
## Summary
- restore the company-based authorization filter for `Product`
- block `Product` mutations when the authenticated actor cannot manage the target company
- add `ProductPeopleService` so supplier/manufacturer/distributor links inherit both the product company boundary and the linked `People` visibility checks

## Related issue
- ControleOnline/app-community#98

## Validation
- reviewed the new branch diff against `master`
- confirmed the authorization flow now touches both `src/Service/ProductService.php` and `src/Service/ProductPeopleService.php`

## Limitations
- this container does not expose `php`, Composer, or the project runtime, so I could not execute automated PHP validation locally in this session
